### PR TITLE
add Travis CI python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 ---
 language: python
-python: "2.7"
+python:
+  - "2.6"
+  - "2.7"
+  - "3.5"
+  - "3.6"
 
 # Use the new container infrastructure
 sudo: false


### PR DESCRIPTION
##### SUMMARY
add Travis CI python versions

- 2.6
- 2.7
- 3.5
- 3.6

These versions are tested in ansible/ansible.
https://github.com/ansible/ansible/blob/devel/tox.ini#L2

##### RELATED ISSUE
None

##### HOW TO VERYFY IT

see Travis CI