### PR TITLE
Feature: nifcloud_fw bulk_authorize

### DIFF
--- a/library/documents/nifcloud_fw.md
+++ b/library/documents/nifcloud_fw.md
@@ -16,18 +16,20 @@ Create or update, authorize, revoke a firewall group.
 
 ## Options
 
-| parameter            | required | default    | type | choices   | aliases | comments                                                                                          |
-|----------------------|----------|------------|------|-----------|---------|---------------------------------------------------------------------------------------------------|
-| access_key           | yes      |            | str  |           |         | NIFCLOUD API access key                                                                           |
-| secret_access_key    | yes      |            | str  |           |         | NIFCLOUD API secret access key                                                                    |
-| endpoint             | yes      |            | str  |           |         | API endpoint of target region                                                                     |
-| group_name           | yes      |            | str  |           | name    | Target firewall group ID                                                                          |
-| description          | no       |            | str  |           |         | Description of target firewall group                                                              |
-| availability_zone    | no       |            | str  |           |         | Availability zone                                                                                 |
-| log_limit            | no       |            | int  |           |         | The upper limit number of logs to retain of communication rejected by the firewall settings rules |
-| ip_permissions       | no       | list()     | list |           |         | List of rules that allows incoming or outgoing communication to resources                         |
-| state                | no       | "present"  | str  | "present" |         | Goal status                                                                                       |
-| purge_ip_permissions | no       | True       | bool |           |         | Purge existing ip permissions that are not found in ip permissions                                |
+| parameter            | required | default    | type | choices   | aliases | comments                                                                                                                                                               |
+|----------------------|----------|------------|------|-----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| access_key           | yes      |            | str  |           |         | NIFCLOUD API access key                                                                                                                                                |
+| secret_access_key    | yes      |            | str  |           |         | NIFCLOUD API secret access key                                                                                                                                         |
+| endpoint             | yes      |            | str  |           |         | API endpoint of target region                                                                                                                                          |
+| group_name           | yes      |            | str  |           | name    | Target firewall group ID                                                                                                                                               |
+| description          | no       |            | str  |           |         | Description of target firewall group                                                                                                                                   |
+| availability_zone    | no       |            | str  |           |         | Availability zone                                                                                                                                                      |
+| log_limit            | no       |            | int  |           |         | The upper limit number of logs to retain of communication rejected by the firewall settings rules                                                                      |
+| ip_permissions       | no       | list()     | list |           |         | List of rules that allows incoming or outgoing communication to resources                                                                                              |
+| state                | no       | "present"  | str  | "present" |         | Goal status                                                                                                                                                            |
+| purge_ip_permissions | no       | True       | bool |           |         | Purge existing ip permissions that are not found in ip permissions                                                                                                     |
+| authorize_in_bulk    | no       | False      | bool |           |         | Authorize ip_permissions for each group. Instead of taking a short time, It will shorten the execution time, but will not guarantee the order of ip_permission instead |
+
 
 ## Examples
 


### PR DESCRIPTION
##### SUMMARY

This p-r add option `bulk_authorize`

nifcloud_fw calls AuthorizeSecurityGroupIngress one by one.

because:
https://github.com/nifcloud/ansible-role-nifcloud/blob/master/library/nifcloud_fw.py#L506

However, this specification spends many time when playbook has many ip_permissons.

For example, if the playbook has 20 groups × 10 IPs and 1 settings spent 20 seconds, ansible-paybook execution spends about 1 hours.

So, I implemented option `bulk_authorize`. When `bulk_authorize` is sets to True, authorize ip_permission for each group.

##### HOW TO VERYFY IT

`make test` and run `ansible-playbook`