### PR TITLE
Fix: python3 startup script signature

### DIFF
--- a/library/nifcloud.py
+++ b/library/nifcloud.py
@@ -218,7 +218,7 @@ def configure_user_data(module, params):
                 **startup_script_vars
             )
             startup_script_bytes = startup_script.encode('utf-8')
-            params['UserData'] = base64.b64encode(startup_script_bytes)
+            params['UserData'] = base64.b64encode(startup_script_bytes).decode()  # noqa
             params['UserData.Encoding'] = 'base64'
     except IOError:
         if 'UserData' in params:

--- a/library/tests/test_nifcloud.py
+++ b/library/tests/test_nifcloud.py
@@ -164,6 +164,34 @@ class TestNifcloud(unittest.TestCase):
             b'dHOoGcBgO14Roaioryic9IdFPg7G+lihZ8Wyoa25ok4='
         )
 
+    # calculate signature with user_data
+    def test_calculate_signature_with_user_data(self):
+        secret_access_key = self.mockModule.params['secret_access_key']
+        method = 'POST'
+        endpoint = self.mockModule.params['endpoint']
+        path = '/api/'
+        params = dict(
+            Action='RunInstances',
+            AccessKeyId=self.mockModule.params['access_key'],
+            SignatureMethod='HmacSHA256',
+            SignatureVersion='2',
+        )
+
+        params['InstanceId.1'] = self.mockModule.params['instance_id']
+        nifcloud.configure_user_data(self.mockModule, params)
+
+        signature = nifcloud.calculate_signature(
+            secret_access_key,
+            method,
+            endpoint,
+            path,
+            params
+        )
+        self.assertEqual(
+            signature,
+            b'IiT263IgchyBDh6RsJaRXa3Tnaz4GXTSm2Jc9uFUxdQ='
+        )
+
     # method get
     def test_request_to_api_get(self):
         method = 'GET'


### PR DESCRIPTION
##### SUMMARY

When `startup_script` parameter is given in nifcloud.py on python3, caluculated signature is incorrect value.

Python3 sample code
```
>>> startup_script = 'aa'
>>> startup_script_bytes = startup_script.encode('utf-8')
>>> startup_script_bytes
b'aa'
>>> user_data = base64.b64encode(startup_script_bytes)
>>> user_data
b'YWE='
>>>
>>> str(user_data)
"b'YWE='"
```
see: 
https://github.com/nifcloud/ansible-role-nifcloud/blob/master/library/nifcloud.py#L207
https://github.com/nifcloud/ansible-role-nifcloud/blob/master/library/nifcloud.py#L129

`str(user_data)` is string "b'YWE='" on python3. but the correct value is "YWE=".

I fixed it.

##### RELATED ISSUE
none

##### HOW TO VERYFY IT

see test