### PR TITLE
Update requests version to 2.20.0

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,4 +18,5 @@
   local_action:
     module: pip
     name: requests
-    version: 2.5.3
+    version: 2.20.0
+    extra_args: --ignore-installed


### PR DESCRIPTION
##### SUMMARY

The version of requests package is old.  
So Updated to 2.20.0 which is solved vulnerability etc.

##### HOW TO VERYFY IT

Confirm test is successful.