### PR TITLE
use Python 3.6.15 instead of 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM python:2.7
+FROM python:3.6.15
 RUN pip install ansible coverage nose mock requests
 WORKDIR /work

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requirements
 ------------
 
 * Distribution = CentOS / Ubuntu
-* python >= 2.6 or 3.x (localhost)
+* python >= 3.6.15
 
 Role Variables
 --------------


### PR DESCRIPTION
##### SUMMARY

- [x] bump python to 3.6.15

##### RELATED ISSUE

- https://github.com/nifcloud/ansible-role-nifcloud/issues/63
- https://github.com/nifcloud/ansible-role-nifcloud/issues/53

##### HOW TO VERYFY IT

- [x] LGTM