### PR TITLE
Feat/add tox

### DIFF
--- a/.github/workflows/syntax-check.yaml
+++ b/.github/workflows/syntax-check.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6.15"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up python

--- a/.github/workflows/test-module.yaml
+++ b/.github/workflows/test-module.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6.15"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up python
@@ -18,11 +18,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependences from pip
       shell: bash
-      run: pip install ansible nose coveralls mock requests coverage
+      run: pip install ansible pytest coveralls mock requests coverage
     - name: NIFCLOUD modules check
       shell: bash
       run: |
-        nosetests --no-byte-compile --with-coverage --cover-package=library/ --where=library/
+        coverage run --source=library -m pytest library/tests/
         coverage xml
     - name: Coveralls
       uses: coverallsapp/github-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,16 @@
-FROM python:2.7
-RUN pip install ansible coverage nose mock requests
-WORKDIR /work
+FROM 31z4/tox
+
+USER root
+
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends \
+        python3.6 \
+        python3.7 \
+        python3.8 \
+        python3.9 \
+        python3.10; \
+    rm -rf /var/lib/apt/lists/*
+
+USER tox

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
 
 IMAGE_NAME := "nifcloud/ansible-role-nifcloud"
-
 build:
 	docker build -t ${IMAGE_NAME} .
+
 test:
 	make build
-	docker run --workdir /work/library --rm -ti -v $(PWD):/work ${IMAGE_NAME} bash -c " \
-          nosetests --no-byte-compile --with-coverage && \
-          coverage report --include=./nifcloud*.py"
+	docker run -u $(shell id -u):$(shell id -g) --workdir /work/library --rm -ti -v $(PWD):/work ${IMAGE_NAME}

--- a/library/tox.ini
+++ b/library/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+env_list = 
+    3.9
+    3.10
+    3.11
+    3.12
+    3.13
+
+[testenv]
+deps = 
+    pytest
+    coverage
+    mock
+    requests
+    pytest-cov
+    ansible
+commands = coverage run --source='.' -m pytest tests/


### PR DESCRIPTION
##### SUMMARY

- [ ] 複数バージョンの Python でテストを実行するために tox を導入します
  - tox のサポートバージョンが 3.9 ~ 3.13 のため、 3.8 までのテストは割愛
- [ ] CI でも上記と同等のバージョンのチェックを実施

##### RELATED ISSUE

https://github.com/nifcloud/ansible-role-nifcloud/issues/53

##### HOW TO VERYFY IT

- [ ] lgtm
- [ ] GitHub Actions passed successfully